### PR TITLE
Fix keyboard focus: double rAF, close button DOM order, focus-visible…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **GuideFlow** (779 symbols, 1364 relationships, 44 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **GuideFlow** (781 symbols, 1366 relationships, 44 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **GuideFlow** (779 symbols, 1364 relationships, 44 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **GuideFlow** (781 symbols, 1366 relationships, 44 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/src/GuideFlow/Components/GuideFlowStep.razor
+++ b/src/GuideFlow/Components/GuideFlowStep.razor
@@ -27,12 +27,6 @@
             {
                 <div class="gf-step__header">
                     <h3 class="gf-step__title" id="@($"gf-step-title-{_stepId}")">@Title</h3>
-                    @if (ResolvedShowClose)
-                    {
-                        <button class="gf-step__close" @onclick="HandleCloseClick" aria-label="@ResolvedCloseLabel">
-                            &times;
-                        </button>
-                    }
                 </div>
             }
 
@@ -92,6 +86,13 @@
                     }
                 </div>
             </div>
+
+            @if (ResolvedShowClose)
+            {
+                <button class="gf-step__close" @onclick="HandleCloseClick" aria-label="@ResolvedCloseLabel">
+                    &times;
+                </button>
+            }
         </div>
 
         @* Screen reader announcement: live region announces step content when it changes *@

--- a/src/GuideFlow/Components/GuideFlowStep.razor.css
+++ b/src/GuideFlow/Components/GuideFlowStep.razor.css
@@ -82,19 +82,32 @@
 }
 
 .gf-step__close {
-    all: unset;
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: none;
+    border: none;
+    appearance: none;
     box-sizing: border-box;
     font-size: 18px;
     line-height: 1;
     cursor: pointer;
     color: var(--gf-close-color, #767676);
-    padding: 0;
+    padding: 4px;
     margin: 0;
     transition: color 0.15s;
+    outline: none;
+    z-index: 1;
 }
 
 .gf-step__close:hover {
     color: var(--gf-text-color, #2d2d2d);
+}
+
+.gf-step__close:focus-visible {
+    outline: 2px solid var(--gf-btn-primary-bg, #4361ee);
+    outline-offset: 2px;
+    border-radius: 2px;
 }
 
 .gf-step__body {

--- a/src/GuideFlow/wwwroot/guideflow.module.js
+++ b/src/GuideFlow/wwwroot/guideflow.module.js
@@ -799,8 +799,20 @@ export function setupStep(stepElement, dotNetRef, trapFocus) {
         _preTourFocusElement = document.activeElement;
     }
     const el = resolveElement(stepElement);
-    if (el && typeof el.focus === 'function') {
-        el.focus();
+    if (el) {
+        // Double rAF: first waits for layout, second waits for paint
+        requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+                const firstFocusable = el.querySelector(
+                    'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+                );
+                if (firstFocusable) {
+                    firstFocusable.focus();
+                } else if (typeof el.focus === 'function') {
+                    el.focus();
+                }
+            });
+        });
     }
 
     _activeKeyHandler = (e) => {
@@ -811,17 +823,19 @@ export function setupStep(stepElement, dotNetRef, trapFocus) {
                 break;
             case 'ArrowRight':
             case 'ArrowDown':
-            case 'Enter':
-                if (document.activeElement?.tagName !== 'BUTTON') {
-                    e.preventDefault();
-                    dotNetRef.invokeMethodAsync('OnKeyboardNext');
-                }
+                e.preventDefault();
+                dotNetRef.invokeMethodAsync('OnKeyboardNext');
                 break;
             case 'ArrowLeft':
             case 'ArrowUp':
+                e.preventDefault();
+                dotNetRef.invokeMethodAsync('OnKeyboardBack');
+                break;
+            case 'Enter':
+                // Let Enter work natively on buttons, navigate only if not on button
                 if (document.activeElement?.tagName !== 'BUTTON') {
                     e.preventDefault();
-                    dotNetRef.invokeMethodAsync('OnKeyboardBack');
+                    dotNetRef.invokeMethodAsync('OnKeyboardNext');
                 }
                 break;
         }


### PR DESCRIPTION
… styles

- Use double requestAnimationFrame for reliable focus after Blazor render
- Move close button to end of DOM (after footer) for proper tab order
- Position close button visually at top-right via CSS absolute positioning
- Replace all:unset with specific resets on close button
- Add :focus-visible style on close button for visible focus indicator
- Arrow keys navigate steps without blocking on button focus
- Enter lets native button click work when focused on button